### PR TITLE
[dev] Speed improvements (now about three times as fast)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,4 +2,4 @@ inst
 README.qmd
 .gitignore
 CHANGELOG.md
-
+Makefile

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,4 +1,5 @@
 inst
 README.qmd
 .gitignore
+CHANGELOG.md
 

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,4 @@
 inst
 README.qmd
+.gitignore
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+
+
+# Ignore compiled shared objects (C)
+/src/*.o
+/src/*.so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+
+
+Version 0.1-0
+=============
+
+* Added C functions for calculating PDF, CDF, and pmax when
+    doing predictions. Currently `predict()` allows for an
+    undocumented input argument `useC = TRUE` (defaults to `FALSE`)
+    for testing. Roughly 3-5 times faster than plain R.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@ Version 0.1-0
     doing predictions. Currently `predict()` allows for an
     undocumented input argument `useC = TRUE` (defaults to `FALSE`)
     for testing. Roughly 3-5 times faster than plain R.
+* Several speed/performance improvements.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: TransitionModels
 Title: Flexible Transition Models for Probabilistic Learning
 Version: 0.1-0
-Date: 2024-12-11
+Date: 2024-12-24
 Authors@R: c(person(
                given = "Nikolaus", 
                family = "Umlauf", 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,14 @@ VERSION := $(shell grep '^Version:' DESCRIPTION | awk '{print $$2}')
 
 .PHONY: install
 install:
-	@echo Current version $(VERSION)
+	@echo Installing current version: $(VERSION)
 	(cd ../ && \
 		R CMD build --no-build-vignettes TransitionModels && \
 		R CMD INSTALL TransitionModels_$(VERSION).tar.gz)
+
+.PHONY: check
+check:
+	@echo Checking current version: $(VERSION)
+	(cd ../ && \
+		R CMD build --no-build-vignettes TransitionModels && \
+		R CMD check --as-cran TransitionModels_$(VERSION).tar.gz)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,3 +1,5 @@
+useDynLib(TransitionModels, .registration = TRUE, .fixes = "C_")
+
 import("Formula")
 import("mgcv")
 import("topmodels")
@@ -7,7 +9,8 @@ importFrom("grDevices", "rgb")
 importFrom("graphics", "barplot", "grid", "hist", "lines", "par",
   "points", "rug")
 
-importFrom("stats", "as.formula", "binomial", "density", "dnorm",
+importFrom("stats", "median", "runif",
+  "as.formula", "binomial", "density", "dnorm",
   "fitted", "lm", "model.frame", "model.response", "na.omit",
   "pnorm", "ppoints", "predict", "qnorm", "qqnorm",
   "quantile", "residuals", "sd", "terms", "update")
@@ -26,4 +29,3 @@ S3method(summary, tm)
 S3method(print, tm)
 S3method(rootogram, tm)
 
-useDynLib(TransitionModels, .registration = TRUE)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -26,3 +26,4 @@ S3method(summary, tm)
 S3method(print, tm)
 S3method(rootogram, tm)
 
+useDynLib(TransitionModels, .registration = TRUE)

--- a/R/TransitionModels.R
+++ b/R/TransitionModels.R
@@ -644,7 +644,7 @@ logLik.tm <- function(object, newdata = NULL, ...)
   if(is.null(newdata)) {
     p <- object$probs$pdf
   } else {
-    p <- predict(object, newdata = newdata, type = "pdf")
+    p <- predict(object, newdata = newdata, type = "pdf", ...)
   }
   ll <- sum(log(p))
   attr(ll, "nobs") <- nrow(object$model.frame)

--- a/R/TransitionModels.R
+++ b/R/TransitionModels.R
@@ -185,7 +185,6 @@ tm_predict <- function(object, newdata,
     t2 <- Sys.time()
   } ## end !useC
 
-  print(head(probs))
   message(sprintf(" Time taken: %12.8f secs", as.numeric(t2 - t1, unit = "secs")))
   message("    Method: ", ifelse(useC, "C", "R"), " implementation")
   message("    Sum result:  ", sum(probs), "\n")

--- a/R/TransitionModels.R
+++ b/R/TransitionModels.R
@@ -158,16 +158,12 @@ tm_predict <- function(object, newdata,
   probs <- numeric(length(ui))
 
   if (useC) {
-    message("Calling C version")
-    t1 <- Sys.time()
-    probs <- .Call("c_tm_predict", ui, nd$index, p, type = type);
-    t2 <- Sys.time()
+    probs <- .Call(C_tm_predict, ui, nd$index, p, type = type);
   }
 
   # -------------------
+  # Original R version, TODO(R): May be removed in the future
   if (!useC) {
-    message("Calling R loop")
-    t1 <- Sys.time()
     for(j in ui) {
 
       pj <- p[nd$index == j]
@@ -216,12 +212,7 @@ tm_predict <- function(object, newdata,
         probs[j] <- which.max(cj) - 1L
       }
     }
-    t2 <- Sys.time()
-  } ## end !useC
-
-  message(sprintf(" Time taken: %12.8f secs", as.numeric(t2 - t1, unit = "secs")))
-  message("    Method: ", ifelse(useC, "C", "R"), " implementation")
-  message("    Sum result:  ", sum(probs), "\n")
+  } ## end !useC (R version)
 
   return(probs)
 }
@@ -297,7 +288,7 @@ tm_dist <- function(y, data = NULL, ...)
 }
 
 timer <- function(msg = NULL) {
-    if (is.null(msg)) ttotal <<- Sys.time()
+    if (is.null(msg) || !exists("ttotal")) ttotal <<- Sys.time()
     if (!is.null(msg) && "treto" %in% ls(envir = .GlobalEnv)) {
         t <- as.numeric(Sys.time() - treto, units = "secs")
         tt <- as.numeric(Sys.time() - ttotal, units = "secs")
@@ -469,7 +460,7 @@ timer(NULL)
   if (useC) {
     ## c_tm_predict_pdfcdf returns a list with PDF and CDF, calculating
     ## both simultanously in C to improve speed.
-    tmp    <- .Call("c_tm_predict_pdfcdf", ui, tmf$index, p)
+    tmp    <- .Call(C_tm_predict_pdfcdf, ui, tmf$index, p)
     probs  <- tmp$pdf
     cprobs <- tmp$cdf
     rm(tmp)

--- a/R/TransitionModels.R
+++ b/R/TransitionModels.R
@@ -121,11 +121,11 @@ tm_predict <- function(object, newdata,
     message("Calling C version")
     t1 <- Sys.time()
     if (type == "pdf") {
-      probs <- .Call("c_predict_pdf_cdf", ui, nd$index, p, type_pdf = TRUE);
+      probs <- .Call("c_tm_predict", ui, nd$index, p, type = type);
     } else if (type == "cdf") {
-      probs <- .Call("c_predict_pdf_cdf", ui, nd$index, p, type_pdf = FALSE);
+      probs <- .Call("c_tm_predict", ui, nd$index, p, type = type);
     } else {
-        stop(type, " in C not yet implemented")
+      probs <- .Call("c_tm_predict", ui, nd$index, p, type = type);
     }
     t2 <- Sys.time()
   }
@@ -172,6 +172,7 @@ tm_predict <- function(object, newdata,
       }
 
       if(type == "pmax") {
+        # That is my count
         cj <- numeric(k)
         cj[1] <- 1 - pj[1]
         if(length(pj) > 1) {
@@ -184,6 +185,7 @@ tm_predict <- function(object, newdata,
     t2 <- Sys.time()
   } ## end !useC
 
+  print(head(probs))
   message(sprintf(" Time taken: %12.8f secs", as.numeric(t2 - t1, unit = "secs")))
   message("    Method: ", ifelse(useC, "C", "R"), " implementation")
   message("    Sum result:  ", sum(probs), "\n")

--- a/R/globals.R
+++ b/R/globals.R
@@ -1,0 +1,7 @@
+
+
+# Global bindings for package checks
+# TODO(R): These are two variables I write into
+#          the globalenv for testing only.
+#          Can be removed in the future.
+utils::globalVariables(c("ttotal", "treto"))

--- a/inst/reto_C.R
+++ b/inst/reto_C.R
@@ -49,6 +49,11 @@ devtools::load_all("../")
 dead_p <- predict(b, newdata = x, type = "pdf", useC = FALSE)
 dead_p <- predict(b, newdata = x, type = "pdf", useC = TRUE)
 
+library("microbenchmark")
+devtools::load_all("../"); microbenchmark(logLik(b, newdata = x, useC = FALSE),
+                                          logLik(b, newdata = x, useC = TRUE),
+                                          times = 1)
+
 dead_p <- predict(b, newdata = x, type = "cdf", useC = FALSE)
 dead_p <- predict(b, newdata = x, type = "cdf", useC = TRUE)
 

--- a/inst/reto_C.R
+++ b/inst/reto_C.R
@@ -1,0 +1,56 @@
+library("TransitionModels")
+library("gamlss2")
+
+if (!file.exists("__tmp.rda")) {
+    library("dplyr")
+    library("sf")
+    library("rnaturalearth")
+    
+    rm(list = objects())
+    
+    # Loading WeatherGermay data set
+    data("WeatherGermany", package = "WeatherGermany")
+    data <- subset(WeatherGermany, !is.na(Wmax))
+    head(data)
+    
+    STARTYEAR <- 2012
+    #STARTYEAR <- 2019
+    ENDYEAR   <- 2019
+    x <- subset(data, id == 722 &
+                      date >= as.Date(sprintf("%04d-01-01", STARTYEAR)) &
+                      date <= as.Date(sprintf("%04d-12-31", ENDYEAR)))
+    
+    x <- subset(x, select = c(id, date, Wmax, name, alt, lat, lon))
+    x$yday <- as.integer(format(x$date, "%j"))
+    x$year <- as.integer(format(x$date, "%Y"))
+    message("Dimension of training data: ", paste(dim(x), collapse = " x "))
+    
+    # Estimating the model
+    f <- Wmax ~ s(yday, bs = "cc")
+    #f <- Wmax ~ s(yday, bs = "cc")
+    system.time(b <- tm(f, data = x, breaks = 100))
+    
+    p <- cbind(p10 = predict(b, newdata = x, type = "quantile", prob = .1),
+               p50 = predict(b, newdata = x, type = "quantile", prob = .5),
+               p90 = predict(b, newdata = x, type = "quantile", prob = .9))
+    matplot(p, type = "l", lwd = 2, lty = 1,
+            main = "Stn 722, year 2019, Percentiles 10/50/90")
+
+    save(b, x, file = "__tmp.rda")
+} else {
+    load("__tmp.rda")
+    print(objects())
+}
+
+#devtools::load_all("../"); dead_p <- predict(b, newdata = x, type = "quantile", prob = .5)
+devtools::load_all("../")
+#dead_p <- predict(b, newdata = x, type = "pdf", useC = FALSE)
+#dead_p <- predict(b, newdata = x, type = "pdf", useC = TRUE)
+
+dead_p <- predict(b, newdata = x, type = "cdf", useC = FALSE)
+dead_p <- predict(b, newdata = x, type = "cdf", useC = TRUE)
+
+#system.time(dead_p <- predict(b, newdata = x, type = "pdf"))
+#system.time(dead_p <- predict(b, newdata = x, type = "quantile"))
+#system.time(dead_p <- predict(b, newdata = x, type = "cdf"))
+

--- a/inst/reto_C.R
+++ b/inst/reto_C.R
@@ -54,3 +54,4 @@ dead_p <- predict(b, newdata = x, type = "cdf", useC = TRUE)
 
 dead_p <- predict(b, newdata = x, type = "pmax", useC = FALSE)
 dead_p <- predict(b, newdata = x, type = "pmax", useC = TRUE)
+

--- a/inst/reto_C.R
+++ b/inst/reto_C.R
@@ -46,12 +46,11 @@ if (!file.exists("__tmp.rda")) {
 
 #devtools::load_all("../"); dead_p <- predict(b, newdata = x, type = "quantile", prob = .5)
 devtools::load_all("../")
-#dead_p <- predict(b, newdata = x, type = "pdf", useC = FALSE)
-#dead_p <- predict(b, newdata = x, type = "pdf", useC = TRUE)
+dead_p <- predict(b, newdata = x, type = "pdf", useC = FALSE)
+dead_p <- predict(b, newdata = x, type = "pdf", useC = TRUE)
 
-#dead_p <- predict(b, newdata = x, type = "cdf", useC = FALSE)
-#dead_p <- predict(b, newdata = x, type = "cdf", useC = TRUE)
+dead_p <- predict(b, newdata = x, type = "cdf", useC = FALSE)
+dead_p <- predict(b, newdata = x, type = "cdf", useC = TRUE)
 
-devtools::load_all("../")
 dead_p <- predict(b, newdata = x, type = "pmax", useC = FALSE)
 dead_p <- predict(b, newdata = x, type = "pmax", useC = TRUE)

--- a/inst/reto_C.R
+++ b/inst/reto_C.R
@@ -1,3 +1,5 @@
+#!/usr/bin/env Rscript
+
 library("TransitionModels")
 library("gamlss2")
 
@@ -47,10 +49,9 @@ devtools::load_all("../")
 #dead_p <- predict(b, newdata = x, type = "pdf", useC = FALSE)
 #dead_p <- predict(b, newdata = x, type = "pdf", useC = TRUE)
 
-dead_p <- predict(b, newdata = x, type = "cdf", useC = FALSE)
-dead_p <- predict(b, newdata = x, type = "cdf", useC = TRUE)
+#dead_p <- predict(b, newdata = x, type = "cdf", useC = FALSE)
+#dead_p <- predict(b, newdata = x, type = "cdf", useC = TRUE)
 
-#system.time(dead_p <- predict(b, newdata = x, type = "pdf"))
-#system.time(dead_p <- predict(b, newdata = x, type = "quantile"))
-#system.time(dead_p <- predict(b, newdata = x, type = "cdf"))
-
+devtools::load_all("../")
+dead_p <- predict(b, newdata = x, type = "pmax", useC = FALSE)
+dead_p <- predict(b, newdata = x, type = "pmax", useC = TRUE)

--- a/inst/reto_sim_speedtest.R
+++ b/inst/reto_sim_speedtest.R
@@ -85,13 +85,17 @@ nd <- dgp_NO(1000, probs = probs)
 
 devtools::load_all("../")
 set.seed(111)
-system.time(
+t1 <- system.time(
     mod1 <- sim_NO(d, nd, breaks = 40, counts = FALSE, family = NO, engine = "bam", useC = FALSE)
 )
 set.seed(111)
-system.time(
+t2 <- system.time(
     mod2 <- sim_NO(d, nd, breaks = 40, counts = FALSE, family = NO, engine = "bam", useC = TRUE)
 )
+message("Speed improvement factor:     x ",  
+        round(t1["elapsed"] / t2["elapsed"] ,2),
+        "   with n = ", n)
+
 
 # Comparing model estimates
 table(coef_comparison = coef(mod1$model) == coef(mod2$model))

--- a/inst/reto_sim_speedtest.R
+++ b/inst/reto_sim_speedtest.R
@@ -1,0 +1,94 @@
+#!/usr/bin/env Rscript
+library("TransitionModels")
+library("gamlss2")
+library("qgam")
+
+
+## Data generating processes.
+dgp_NO <- function(n = 1000, probs = c(0.01, 0.1, 0.5, 0.9, 0.99), breaks = 20, ...)
+{
+  ## Covariate.
+  x <- runif(n, -3, 3)
+
+  ## Parameters.
+  mu <- sin(x)
+  sigma <- exp(-1 + cos(x))
+
+  ## Response
+  y_cont <- rnorm(n, mean = mu, sd = sigma)
+
+  ## Discretize the normal data into count categories.
+  yr <- range(y_cont)
+  breaks <- seq(-4, 4, length.out = breaks)
+  y_count <- cut(y_cont, breaks = breaks, labels = FALSE, include.lowest = TRUE) - 1
+
+  ## Combine.
+  d <- data.frame("x" = x, "counts" = y_count, "num" = y_cont)
+
+  ## Add quantiles.
+  qu <- quc <- NULL
+  for(j in probs) {
+    qj <- qNO(j, mu = mu, sigma = sigma)
+    qu <- cbind(qu, qj)
+    quc <- cbind(quc, cut(qj, breaks = breaks, labels = FALSE, include.lowest = TRUE) - 1)
+  }
+  colnames(qu) <- colnames(quc) <- paste0(probs * 100, "%")
+  d$quantiles <- qu
+  d$count.quantiles <- quc
+
+  return(d)
+}
+
+
+sim_NO <- function(d, nd, breaks, counts = FALSE, family = NO, engine = "bam", useC = FALSE, ...)
+{
+  breaks <- as.integer(breaks)[1L]
+  stopifnot(is.integer(breaks), length(breaks) == 1L, breaks > 0)
+  if(counts) {
+    d$num <- d$counts
+    nd$num <- nd$counts
+    d$quantiles <- d$count.quantiles
+    nd$quantiles <- nd$count.quantiles
+  }
+
+  ## Set quantiles.
+  qu <- colnames(nd$quantiles)
+  qu <- as.numeric(gsub("%", "", qu, fixed = TRUE))/100
+
+  ## Estimate transition model.
+  f <- num ~ s(theta) + s(x) + te(theta,x)
+  message("\n\n ====== running model estimation with useC = ", useC, " ===== \n")
+  b <- tm(f, data = d, breaks = breaks, engine = engine,
+    scale.x = TRUE, size = 40, maxit = 1000, decay = 0.01, useC = useC)
+
+  message("\n\n ====== end of model estimation =========\n\n")
+
+  ## Predict quantiles.
+  p <- do.call("cbind",
+    lapply(qu, function(j) {
+      predict(b, newdata = nd, prob = j, useC = useC)
+  }))
+
+  return(b)
+}
+
+
+# Sim
+n <- 50000
+#n <- 10000
+##n <- 3
+probs <- 0.5
+set.seed(111)
+d  <- dgp_NO(n, probs = probs)
+nd <- dgp_NO(1000, probs = probs)
+
+devtools::load_all("../")
+system.time(
+    mod <- sim_NO(d, nd, breaks = 40, counts = FALSE, family = NO, engine = "bam", useC = FALSE)
+)
+system.time(
+    mod <- sim_NO(d, nd, breaks = 40, counts = FALSE, family = NO, engine = "bam", useC = TRUE)
+)
+
+
+

--- a/inst/reto_sim_speedtest.R
+++ b/inst/reto_sim_speedtest.R
@@ -74,14 +74,19 @@ sim_NO <- function(d, nd, breaks, counts = FALSE, family = NO, engine = "bam", u
 
 
 # Sim
-n <- 50000
+#n <- 50000
 #n <- 10000
-#n <- 2000
+n <- 2000
 ##n <- 3
 probs <- 0.5
 set.seed(111)
 d  <- dgp_NO(n, probs = probs)
 nd <- dgp_NO(1000, probs = probs)
+
+message("    -------------------------------")
+message("       Using N = ", n)
+message("       Calling devtools load_all")
+message("    -------------------------------")
 
 devtools::load_all("../")
 set.seed(111)

--- a/inst/reto_sim_speedtest.R
+++ b/inst/reto_sim_speedtest.R
@@ -76,6 +76,7 @@ sim_NO <- function(d, nd, breaks, counts = FALSE, family = NO, engine = "bam", u
 # Sim
 n <- 50000
 #n <- 10000
+#n <- 2000
 ##n <- 3
 probs <- 0.5
 set.seed(111)
@@ -83,12 +84,21 @@ d  <- dgp_NO(n, probs = probs)
 nd <- dgp_NO(1000, probs = probs)
 
 devtools::load_all("../")
+set.seed(111)
 system.time(
-    mod <- sim_NO(d, nd, breaks = 40, counts = FALSE, family = NO, engine = "bam", useC = FALSE)
+    mod1 <- sim_NO(d, nd, breaks = 40, counts = FALSE, family = NO, engine = "bam", useC = FALSE)
 )
+set.seed(111)
 system.time(
-    mod <- sim_NO(d, nd, breaks = 40, counts = FALSE, family = NO, engine = "bam", useC = TRUE)
+    mod2 <- sim_NO(d, nd, breaks = 40, counts = FALSE, family = NO, engine = "bam", useC = TRUE)
 )
+
+# Comparing model estimates
+table(coef_comparison = coef(mod1$model) == coef(mod2$model))
+table(abs(mod1$probs$pdf - mod2$probs$pdf) < sqrt(.Machine$double.eps))
+print(sqrt(mean((predict(mod1) - predict(mod2))^2)))
+
+sapply(list(mod1 = mod1, mod2 = mod2), logLik)
 
 
 

--- a/man/plot.Rd
+++ b/man/plot.Rd
@@ -12,7 +12,7 @@
 }
 
 \usage{
-\method{plot}{tm}(x, which = "effects", spar = TRUE, ...)
+\method{plot}{tm}(x, which = "effects", spar = TRUE, k = 5, ...)
 }
 
 \arguments{
@@ -30,6 +30,7 @@
     Multiple options can be specified as a character vector or numeric indices.}
   \item{spar}{Logical. If \code{TRUE}, multiple plots are arranged in a
     single window. Default is \code{TRUE}.}
+  \item{k}{Integer, TODO(N): Describe argument. Defaults to \code{5}.}
   \item{\dots}{Additional arguments passed to the underlying plotting functions.}
 }
 

--- a/src/init.c
+++ b/src/init.c
@@ -1,0 +1,28 @@
+
+/* Symbol registration initialization.
+ *
+ * All functions called from R should be registered here (as well as declared
+ * in tm.h). Note that we use a prefix (.fixup = "_C" defined in NAMESPACE).
+ * Functions do _not_ have the C_ prefix in C but need the C_ prefix when
+ * called (.Call()) from R.
+ */
+#include <R.h>
+#include <Rinternals.h>
+#include <R_ext/Rdynload.h>
+
+/* Include package header file */
+#include "tm.h"
+
+static const R_CallMethodDef callMethods[] = {
+  {"tm_predict",             (DL_FUNC) &tm_predict,           4},
+  {"tm_predict_pdfcdf",      (DL_FUNC) &tm_predict_pdfcdf,    3},
+  {NULL, NULL, 0} // Termination entry
+};
+
+
+void R_init_TransitionModels(DllInfo *dll) {
+    /* Registering .Call functions */
+    R_registerRoutines(dll, NULL, callMethods, NULL, NULL);
+    /* Disable dynamic symbol lookup for safety reasons */
+    R_useDynamicSymbols(dll, FALSE);
+}

--- a/src/predict.c
+++ b/src/predict.c
@@ -1,0 +1,107 @@
+
+#include <R.h>
+#include <Rdefines.h>
+#include <Rinternals.h>
+#include <stdbool.h>
+
+#include <stdlib.h>
+
+/* Helper function to find position of x in y
+ *
+ * @param x single integer (the 'needle').
+ * @param y integer vector (the 'haystack').
+ * @param n length of y.
+ * @param count number of elements found (modified inside function).
+ * 
+ * @return returns an integer vector (must be freed outside function)
+ * with the index position of x in y.
+ */
+int* find_positions(int x, int* y, int n, int* count) {
+    int* positions = (int*)malloc(n * sizeof(int)); // Allocate max possible size
+    *count = 0;
+    for (int i = 0; i < n; i++) {
+        if (y[i] == x) {
+            positions[*count] = i; // Store the index
+            (*count)++;
+        }
+    }
+    return positions; // Caller must free this memory
+}
+
+/* Helper function for type = "pdf".
+ *
+ * Calculates (1 - p[count]) * prod(p[-count]) with p = pptr[positions]
+ */
+double c_calc_pdf(int* positions, int count, double* pptr) {
+    double res = 1.0; // Initialize with 1.0 for product
+    for (int i = 0; i < (count - 1); i++) {
+        // Calculates product over the first (count - 1) elements
+        res *= pptr[positions[i]];
+    }
+    // Multiplies (1 - p[count]) * the product from above
+    res *= (1.0 - pptr[positions[count - 1]]);
+    return res;
+}
+
+
+/* Helper function for type = "cdf".
+ *
+ */
+double c_calc_cdf(int* positions, int count, double* pptr) {
+    // Initialize with (1 - p[0])
+    double res = 1.0 - pptr[positions[0]];
+    if (count > 0) {
+        double pprod = 1.0; // Initialize with 1.0 for product
+        // Looping over all elements except first
+        for (int i = 1; i < count; i++) {
+            pprod *= pptr[positions[i - 1]]; // Multiply with previous element
+            res += (1.0 - pptr[positions[i]]) * pprod;
+        }
+    }
+    return res;
+}
+
+/* Calculating elementwise pdf
+ *
+ * @param uidx integer vector with unique indices in data.
+ * @param idx integer with indices, length of idx is sample size times breaks.
+ * @param p probabilities, same length as idx vector.
+ * @param type_pdf logical, if TRUE the PDF is calculated, else the CDF.
+ *
+ * @details Internally loops over all unique indices in `uidx`.
+ * For each index (belonging to one observation) we check the position
+ * of the elements in `idx`, and call the `predict_pdf_calc` function
+ * which calculates and returns the pdf (double).
+ * 
+ * @return Returns SEXP double vector of length (length(uidx)).
+ */
+SEXP c_predict_pdf_cdf(SEXP uidx, SEXP idx, SEXP p, SEXP type_pdf) {
+
+    int    do_pdf = LOGICAL(type_pdf)[0];
+    double *pptr    = REAL(p);
+    int    *uidxptr = INTEGER(uidx);  // Unique indices in the dtaa
+    int    *idxptr  = INTEGER(idx);   // Index vector
+    int    n = LENGTH(idx);
+    int    un = LENGTH(uidx);
+    int    i, count;
+
+    // Initialize results vector
+    SEXP probs;
+    PROTECT(probs = allocVector(REALSXP, un));
+    double *probsptr = REAL(probs);
+
+    for (i = 0; i < un; i++) {
+        int* positions = find_positions(uidxptr[i], idxptr, n, &count);
+        if (do_pdf) {
+            probsptr[i] = c_calc_pdf(positions, count, pptr);
+        } else {
+            probsptr[i] = c_calc_cdf(positions, count, pptr);
+        }
+        free(positions); // Free allocated memory
+    }
+
+    UNPROTECT(1); // Releasing protected objects
+    return probs;
+}
+
+

--- a/src/predict.c
+++ b/src/predict.c
@@ -43,7 +43,6 @@ double c_calc_pdf(int* positions, int count, double* pptr) {
     return res;
 }
 
-
 /* Helper function for type = "cdf".
  *
  */
@@ -61,12 +60,37 @@ double c_calc_cdf(int* positions, int count, double* pptr) {
     return res;
 }
 
+/* Helper function for type = "pmax"
+ *
+ */
+double c_calc_pmax(int* positions, int count, double* pptr) {
+    // Initialize with (1 - p[0])
+    double res = 1.0 - pptr[positions[0]];
+    double max_res = res; // Current maximum
+    int    pmax = 0;      // Position of highest value (max cdf)
+
+    // Does the same as c_calc_cdf except summing up, and only
+    // keeps the index of the highest value.
+    if (count > 0) {
+        double pprod = 1.0; // Initialize with 1.0 for product
+        for (int i = 1; i < count; i++) {
+            pprod *= pptr[positions[i - 1]]; // Multiply with previous element
+            res    = (1.0 - pptr[positions[i]]) * pprod;
+            if (res > max_res) {
+                max_res = res;
+                pmax = i;
+            }
+        }
+    }
+    return pmax; // Return as is (zero based)
+}
+
 /* Calculating elementwise pdf
  *
  * @param uidx integer vector with unique indices in data.
  * @param idx integer with indices, length of idx is sample size times breaks.
  * @param p probabilities, same length as idx vector.
- * @param type_pdf logical, if TRUE the PDF is calculated, else the CDF.
+ * @param type character, either 'pdf', 'cdf', or 'pmax'.
  *
  * @details Internally loops over all unique indices in `uidx`.
  * For each index (belonging to one observation) we check the position
@@ -75,9 +99,8 @@ double c_calc_cdf(int* positions, int count, double* pptr) {
  * 
  * @return Returns SEXP double vector of length (length(uidx)).
  */
-SEXP c_predict_pdf_cdf(SEXP uidx, SEXP idx, SEXP p, SEXP type_pdf) {
+SEXP c_tm_predict(SEXP uidx, SEXP idx, SEXP p, SEXP type) {
 
-    int    do_pdf = LOGICAL(type_pdf)[0];
     double *pptr    = REAL(p);
     int    *uidxptr = INTEGER(uidx);  // Unique indices in the dtaa
     int    *idxptr  = INTEGER(idx);   // Index vector
@@ -85,17 +108,25 @@ SEXP c_predict_pdf_cdf(SEXP uidx, SEXP idx, SEXP p, SEXP type_pdf) {
     int    un = LENGTH(uidx);
     int    i, count;
 
+    // Evaluate 'type' to define what to do
+    const char* thetype = CHAR(STRING_ELT(type, 0));
+    bool do_pdf = strcmp(thetype, "pdf") == 0;
+    bool do_cdf = strcmp(thetype, "cdf") == 0;
+
     // Initialize results vector
     SEXP probs;
     PROTECT(probs = allocVector(REALSXP, un));
     double *probsptr = REAL(probs);
 
+
     for (i = 0; i < un; i++) {
         int* positions = find_positions(uidxptr[i], idxptr, n, &count);
         if (do_pdf) {
             probsptr[i] = c_calc_pdf(positions, count, pptr);
-        } else {
+        } else if (do_cdf) {
             probsptr[i] = c_calc_cdf(positions, count, pptr);
+        } else {
+            probsptr[i] = c_calc_pmax(positions, count, pptr);
         }
         free(positions); // Free allocated memory
     }

--- a/src/tm.h
+++ b/src/tm.h
@@ -1,0 +1,49 @@
+
+/* Strongly inspired by the great mgcv package! */
+
+/* Most compilers with openMP support supply. a pre-defined compiler macro
+ * _OPENMP. Following. facilitates selective turning off (by testing value or
+ * defining multiple versions OPENMP_ON1, OPENMP_ON2...)
+ */
+#if defined _OPENMP
+#define OPENMP_ON 1
+#endif
+
+/* ... note also that there is no actual *need* to protect #pragmas with #ifdef
+ * OPENMP_ON, since C ignores undefined pragmas, but failing to do so may
+ * produce alot of compilation warnings if openMP is not supported In contrast
+ * functions from omp.h must be protected, and there is non-avoidable use of
+ * these in the mgcv code.
+ */
+
+//#define OMP_REPORT // define to have all routines using omp report on start and end.
+#define OMP_REPORT
+
+/* For safe memory handling from R */
+#define CALLOC R_chk_calloc
+#define FREE R_chk_free
+#define REALLOC R_chk_realloc
+
+/* BUT, this can mess up valgrinding for memory error checking - problems are.
+ * sometimes missed because standard allocation is being circumvented. Then
+ * errors can. corrupt R memory management without detection and trigger
+ * nothing until R messes up internally because of corruption, which then makes
+ * it look as if R is generating the problem. Hence better to reset for
+ * checking. Also sizing errors in .C often generate no obvious valgrind error.
+ */
+//#define CALLOC calloc
+//#define FREE free
+//#define REALLOC realloc
+
+/* ------------------------------------------------------------------------ */
+
+void fun(double *y, double *H);
+int* find_position(int x, int* y, int n, int* count);
+double tm_calc_pdf(int* positions, int count, double* pptr);
+double tm_calc_cdf(int* positions, int count, double* pptr);
+double tm_calc_pmax(int* positions, int count, double* pptr);
+
+SEXP tm_predict(SEXP uidx, SEXP idx, SEXP p, SEXP type);
+SEXP tm_predict_pdfcdf(SEXP uidx, SEXP idx, SEXP p);
+
+


### PR DESCRIPTION
Hy @freezenik 

**this pull request is not intended to be merged**, but I thought I'll go via pull request to show the changes I made so far.  In the current version of the `predictc` branch, there is a lot of development output, timing, and duplicated code which I need to remove, but let us do that next year when we meet in person again.

### Main changes

The main changes I made so far are:

* Implemented CDF, PDF, and pmax in plain C (2-3 times faster)
* Strongly improved the `tm_data()` function in R (plain R)

Currently, `tm()`, and `predict.tm()` have a `useC` argument. When set `TRUE`, my improved code is used. If `FALSE` the code from the current main branch is used - just for comparison.

I will remove all that code (and the option) in the neat future before making a 'serious' pull request to merge back to the main branch (currently this is all on the `predictc` branch).

### Speed improvements (numbers)

I am using a simplified of your simulation code (`sim_NO`; `inst/reto_sim_speedtest.R`) using `bam` to estimate the model. I drew different sets of random numbers to train the model with up to `n = 50000` (`breaks = 40`).

With `n = 10000`

* Getting a solid speed improvement factor of `2.70` (nearly 3 times as fast).
* About 44 percent of the improved version is spent for the estimation (bam)

With `n = 50000`

* Getting a solid speed improvement factor of `3.10`.
* About 20 percent of the improved version is spent for the estimation (bam)
* The majority of the remaining time (80 percent) is used to calculate CDF/PDF.

### Further improvements

* `bam` parallelizes in the background, we should think
    to do this as well when calculating pdf/cdf; either in C (but
    I remember that then only works on UNIX) or using parallelization
    in R; calculating CDF/PDF blockwise?

Greez
R